### PR TITLE
uhu: make sure label option exists when formatting

### DIFF
--- a/uhu/odroid-c2.uhupkg.config
+++ b/uhu/odroid-c2.uhupkg.config
@@ -40,6 +40,7 @@
             {
                 "filename": "$IMAGE_BASENAME-$MACHINE.tar.xz",
                 "filesystem": "ext4",
+                "format-options": "-L system_a",
                 "format?": true,
                 "mode": "tarball",
                 "target": "/dev/disk/by-label/system_a",
@@ -87,6 +88,7 @@
             {
                 "filename": "$IMAGE_BASENAME-$MACHINE.tar.xz",
                 "filesystem": "ext4",
+                "format-options": "-L system_b",
                 "format?": true,
                 "mode": "tarball",
                 "target": "/dev/disk/by-label/system_b",


### PR DESCRIPTION
This fixes the following issue:

transient error: couldn't format '/dev/disk/by-label/system_a'. cmdline error: Error executing command 'mkfs.ext4
-F -L system_a /dev/disk/by-label/system_a': mke2fs 1.43.5 (04-Aug-2017)\n
The file /dev/disk/by-label/system_a does not exist and no size was specified

If the label is not present when formatting the device,
this one does not exists anymore and update fails.

Signed-off-by: Pierre-Jean TEXIER <texier.pj2@gmail.com>